### PR TITLE
[launch] console logging working (not prints)

### DIFF
--- a/launch/mock_robot.launch.py
+++ b/launch/mock_robot.launch.py
@@ -29,11 +29,24 @@ import launch_ros.actions
 
 def generate_launch_description():
     """Launch the mock robot."""
-    return launch.LaunchDescription([
+    launch_description = launch_ros.get_default_launch_description()
+    launch_description.add_action(
         launch_ros.actions.Node(
             package='py_trees_ros_tutorials', node_executable='mock-dashboard', output='screen',
-            node_name='dashboard'),
+            node_name='dashboard')
+    )
+    launch_description.add_action(
         launch_ros.actions.Node(
             package='py_trees_ros_tutorials', node_executable='mock-led-strip',  output='screen',  # screen is awkward, it's after the fact
-            node_name='led_strip'),
-    ])
+            node_name='led_strip')
+    )
+    print("Dude")
+    return launch_description
+#     return launch.LaunchDescription([
+#         launch_ros.actions.Node(
+#             package='py_trees_ros_tutorials', node_executable='mock-dashboard', output='screen',
+#             node_name='dashboard'),
+#         launch_ros.actions.Node(
+#             package='py_trees_ros_tutorials', node_executable='mock-led-strip',  output='screen',  # screen is awkward, it's after the fact
+#             node_name='led_strip'),
+#     ])

--- a/py_trees_ros_tutorials/mock/dashboard.py
+++ b/py_trees_ros_tutorials/mock/dashboard.py
@@ -139,9 +139,9 @@ class Backend(qt_core.QObject):
         print("Got callback")
         colour = "grey"
         if not msg.data:
-            self.node.get_logger().info("Dashboard: no color specified, setting '{}'".format(colour))
+            self.node.get_logger().info("no colour specified, setting '{}'".format(colour))
         elif msg.data not in ["grey", "blue", "red", "green"]:
-            self.node.get_logger().info("Dashboard: received unsupported LED colour '{0}', setting '{1}'".format(msg.data, colour))
+            self.node.get_logger().info("received unsupported LED colour '{0}', setting '{1}'".format(msg.data, colour))
         else:
             colour = msg.data
         self.led_colour_changed.emit(colour)

--- a/py_trees_ros_tutorials/mock/led_strip.py
+++ b/py_trees_ros_tutorials/mock/led_strip.py
@@ -127,7 +127,7 @@ class LEDStrip(object):
             text = self.generate_led_text(msg.data)
             # don't bother publishing if nothing changed.
             if self.last_text != text:
-                print("{}".format(text))
+                self.node.get_logger().info("{}".format(text))
                 self.last_text = text
                 self.last_uuid = uuid.uuid4()
                 self.display_publisher.publish(std_msgs.String(data=msg.data))


### PR DESCRIPTION
This partially solves #2. It uses the `launch_ros` description, which sets up a handler to catch node logging. 

Caveat: it does not catch regular print style logging.