### PR TITLE
[documentation] mock and root level module documentation

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -9,6 +9,7 @@ encoding//py_trees_ros_tutorials/mock/gui/configuration_group_box.py=utf-8
 encoding//py_trees_ros_tutorials/mock/gui/configuration_group_box_ui.py=utf-8
 encoding//py_trees_ros_tutorials/mock/gui/dashboard_group_box.py=utf-8
 encoding//py_trees_ros_tutorials/mock/gui/main_window.py=utf-8
+encoding//py_trees_ros_tutorials/mock/gui/main_window_rc.py=utf-8
 encoding//py_trees_ros_tutorials/mock/launch.py=utf-8
 encoding//py_trees_ros_tutorials/mock/led_strip.py=utf-8
 encoding//py_trees_ros_tutorials/mock/move_base.py=utf-8

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,7 +8,7 @@ all:
 	@echo "    clean: clean out the html directory"
 
 docs:
-	sphinx-build -v -b html . html
+	sphinx-build -vv -b html . html
 
 clean:
 	rm -rf html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,6 +63,7 @@ exclude_patterns = ['.build', 'weblinks.rst']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'py_trees': ('https://py-trees.readthedocs.io/en/release-1.2.x', None),
+    'py_trees_ros': ('https://py-trees-ros.readthedocs.io/en/release-1.0.x', None),
     'rclpy': ('http://docs.ros2.org/crystal/api/rclpy/', None),
 }
 
@@ -162,9 +163,13 @@ todo_include_todos = True
 
 MOCK_MODULES = [
     'action_msgs', 'action_msgs.msg',
-    'py_trees_ros', 'py_trees_ros.mock',
+    'geometry_msgs', 'geometry_msgs.msg',
+    'launch', 'launch_ros', 'launch_ros.actions',
+    'py_trees_ros', 'py_trees_ros.exceptions', 'py_trees_ros.mock',
+    'py_trees_ros.mock.actions',
     'py_trees_ros_interfaces', 'py_trees_ros_interfaces.action',
     'py_trees_ros_interfaces.msg', 'py_trees_ros_interfaces.srv',
+    'rcl_interfaces', 'rcl_interfaces.msg', 'rcl_interfaces.srv',
     'rclpy', 'rclpy.action', 'rclpy.callback_groups', 'rclpy.executors',
     'rclpy.expand_topic_name', 'rclpy.node', 'rclpy.parameter',
     'rclpy.qos', 'rclpy.time',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -165,6 +165,8 @@ MOCK_MODULES = [
     'action_msgs', 'action_msgs.msg',
     'geometry_msgs', 'geometry_msgs.msg',
     'launch', 'launch_ros', 'launch_ros.actions',
+    # https://github.com/splintered-reality/py_trees_ros_tutorials/issues/18#issuecomment-487982404
+    # 'PyQt5', 'PyQt5.QtCore', 'PyQt5.QtWidgets',
     'py_trees_ros', 'py_trees_ros.exceptions', 'py_trees_ros.mock',
     'py_trees_ros.mock.actions',
     'py_trees_ros_interfaces', 'py_trees_ros_interfaces.action',
@@ -178,12 +180,10 @@ MOCK_MODULES = [
     'std_msgs', 'std_msgs.msg',
     'unique_identifier_msgs', 'unique_identifier_msgs.msg'
 ]
-# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = unittest.mock.Mock()
 
-# This would be nice if it worked, but it doesn't handle submodules well
-# autodoc_mock_imports = MOCK_MODULES
+# Has some caveats, see
+#    https://github.com/splintered-reality/py_trees_ros_tutorials/issues/18#issuecomment-487975890
+autodoc_mock_imports = MOCK_MODULES
 
 ##############################################################################
 # Default Sphinx

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ Behaviour trees for ros in python.
    :maxdepth: 1
    :caption: Reference
 
+   modules
    changelog
 
 Indices and tables

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -1,0 +1,72 @@
+.. _modules-section-label:
+
+Module API
+==========
+
+py_trees_ros_tutorials
+----------------------
+
+.. automodule:: py_trees_ros_tutorials
+   :synopsis: tutorials for py_trees in ros
+
+py_trees_ros_tutorials.mock
+---------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock
+   :synopsis: utilities and components for mocking a robot
+
+py_trees_ros_tutorials.mock.actions
+-----------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.actions
+    :members:
+    :show-inheritance:
+    :synopsis: reusable action clients for testing mock components
+
+py_trees_ros_tutorials.mock.battery
+-----------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.battery
+    :members:
+    :show-inheritance:
+    :synopsis: mock the state of a battery component
+
+py_trees_ros_tutorials.mock.launch
+----------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.launch
+    :members:
+    :show-inheritance:
+    :synopsis: a python launcher for all mock robot processes
+
+py_trees_ros_tutorials.mock.led_strip
+-------------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.led_strip
+    :members:
+    :show-inheritance:
+    :synopsis: mock a led strip notification server
+
+py_trees_ros_tutorials.mock.move_base
+-------------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.move_base
+    :members:
+    :show-inheritance:
+    :synopsis: mock the ROS navistack move base
+
+py_trees_ros_tutorials.mock.rotate
+----------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.rotate
+    :members:
+    :show-inheritance:
+    :synopsis: mock a very simple rotation action server
+
+py_trees_ros_tutorials.mock.safety_sensors
+------------------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.safety_sensors
+    :members:
+    :show-inheritance:
+    :synopsis: mock a safety sensor pipeline, requires context switching

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -9,6 +9,22 @@ py_trees_ros_tutorials
 .. automodule:: py_trees_ros_tutorials
    :synopsis: tutorials for py_trees in ros
 
+py_trees_ros_tutorials.utilities
+--------------------------------
+
+.. automodule:: py_trees_ros_tutorials.utilities
+    :members:
+    :show-inheritance:
+    :synopsis: utilities for the tutorials and launchers
+
+py_trees_ros_tutorials.version
+------------------------------
+
+.. automodule:: py_trees_ros_tutorials.version
+    :members:
+    :show-inheritance:
+    :synopsis: package version number for users of the package
+
 py_trees_ros_tutorials.mock
 ---------------------------
 
@@ -78,4 +94,3 @@ py_trees_ros_tutorials.mock.safety_sensors
     :members:
     :show-inheritance:
     :synopsis: mock a safety sensor pipeline, requires context switching
-

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -31,6 +31,14 @@ py_trees_ros_tutorials.mock.battery
     :show-inheritance:
     :synopsis: mock the state of a battery component
 
+py_trees_ros_tutorials.mock.dock
+--------------------------------
+
+.. automodule:: py_trees_ros_tutorials.mock.dock
+    :members:
+    :show-inheritance:
+    :synopsis: mock a docking controller
+
 py_trees_ros_tutorials.mock.launch
 ----------------------------------
 
@@ -70,3 +78,4 @@ py_trees_ros_tutorials.mock.safety_sensors
     :members:
     :show-inheritance:
     :synopsis: mock a safety sensor pipeline, requires context switching
+

--- a/py_trees_ros_tutorials/__init__.py
+++ b/py_trees_ros_tutorials/__init__.py
@@ -7,7 +7,7 @@
 ##############################################################################
 
 """
-Modules supporting the mock robot and tutorials for py_trees on ROS2.
+A mock robot and tutorials for py_trees on ROS2.
 """
 
 ##############################################################################

--- a/py_trees_ros_tutorials/mock/__init__.py
+++ b/py_trees_ros_tutorials/mock/__init__.py
@@ -7,7 +7,7 @@
 ##############################################################################
 
 """
-This package contains mock nodes for ROS py_trees simulations.
+A mocked robot for use in the tutorials.
 """
 ##############################################################################
 # Imports

--- a/py_trees_ros_tutorials/mock/battery.py
+++ b/py_trees_ros_tutorials/mock/battery.py
@@ -9,7 +9,7 @@
 ##############################################################################
 
 """
-Mocks a battery provider.
+Mock the state of a battery component.
 """
 
 
@@ -31,27 +31,29 @@ import sys
 
 class Battery(object):
     """
-    Mocks the processed battery state for a robot (/battery/sensor_state)
-    as well as a possible charging source (/battery/charging_source).
+    Mocks the processed battery state for a robot (/battery/sensor_state).
+
+    Node Name:
+        * **battery**
 
     ROS Publishers:
         * **~state** (:class:`sensor_msgs.msg.BatteryState`)
 
           * full battery state information
 
-    Dynamic Reconfigure:
+    Dynamic Parameters:
         * **~charging_percentage** (:obj:`float`)
 
-          * one-step setting of the current battery percentage
+          * one-shot setter of the current battery percentage
         * **~charging** (:obj:`bool`)
 
-          * whether it is currently charging or not
+          * charging or discharging
         * **~charging_increment** (:obj:`float`)
 
-          * how fast it charges/discharges
+          * the current charging/discharging increment
 
-    On startup it is in a DISCHARGING state. Use the ``dashboard`` to dynamically
-    reconfigure the parameters.
+    On startup it is in a DISCHARGING state and updates every 200ms.
+    Use the ``dashboard`` to dynamically reconfigure parameters.
     """
     def __init__(self):
         # node
@@ -91,7 +93,7 @@ class Battery(object):
 
     def spin(self):
         """
-        Spin around, updating battery state and publishing the result.
+        Create a timer for the periodic update and spin.
         """
         # TODO: with rate and spin_once, once rate is implemented in rclpy
         unused_timer = self.node.create_timer(
@@ -106,7 +108,7 @@ class Battery(object):
 
     def update_and_publish(self):
         """
-        Update and publish.
+        Timer callback that processes the battery state update and publishes.
         """
         # parameters
         charging = self.node.get_parameter("charging").value
@@ -152,7 +154,7 @@ def main():
     """
     Entry point for the mock batttery node.
     """
-    parser = argparse.ArgumentParser(description='Mock a battery/charging source')
+    parser = argparse.ArgumentParser(description='Mock the state of a battery component')
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]
     parser.parse_args(command_line_args)
     rclpy.init()  # picks up sys.argv automagically internally

--- a/py_trees_ros_tutorials/mock/battery.py
+++ b/py_trees_ros_tutorials/mock/battery.py
@@ -36,7 +36,7 @@ class Battery(object):
     Node Name:
         * **battery**
 
-    ROS Publishers:
+    Publishers:
         * **~state** (:class:`sensor_msgs.msg.BatteryState`)
 
           * full battery state information
@@ -147,6 +147,9 @@ class Battery(object):
         self.publishers.state.publish(msg=self.battery)
 
     def shutdown(self):
+        """
+        Cleanup ROS components.
+        """
         self.node.destroy_node()
 
 

--- a/py_trees_ros_tutorials/mock/dashboard.py
+++ b/py_trees_ros_tutorials/mock/dashboard.py
@@ -8,7 +8,7 @@
 # Documentation
 ##############################################################################
 """
-Launch a qt dashboard for the tutorials.
+A qt dashboard for interactions with the mock robot
 """
 ##############################################################################
 # Imports

--- a/py_trees_ros_tutorials/mock/dock.py
+++ b/py_trees_ros_tutorials/mock/dock.py
@@ -23,8 +23,6 @@ import py_trees_ros_interfaces.action as py_trees_actions
 import rclpy
 import sys
 
-from . import actions
-
 ##############################################################################
 # Class
 ##############################################################################
@@ -32,9 +30,21 @@ from . import actions
 
 class Dock(py_trees_ros.mock.actions.GenericServer):
     """
-    Simple server that docks if the goal is true, undocks otherwise.
+    Simple action server that docks/undocks depending on the instructions
+    in the goal requests.
+
+    Node Name:
+        * **docking_controller**
+
+    Action Servers:
+        * **/dock** (:class:`py_trees_ros_interfaces.action.Dock`)
+
+          * docking/undocking control
+
+    Args:
+        duration: mocked duration of a successful docking/undocking action
     """
-    def __init__(self, duration=2.0):
+    def __init__(self, duration: float=2.0):
         super().__init__(
             node_name="docking_controller",
             action_name="dock",
@@ -45,16 +55,22 @@ class Dock(py_trees_ros.mock.actions.GenericServer):
         )
 
     def goal_received_callback(self, goal):
+        """
+        Set the title of the action depending on whether a docking
+        or undocking action was requestions ('Dock'/'UnDock')
+        """
         if goal.dock:
             self.title = "Dock"
         else:
             self.title = "UnDock"
 
-    def generate_feedback_message(self):
+    def generate_feedback_message(self) -> py_trees_actions.Dock_Feedback:
         """
-        Create some appropriate feedback.
+        Create a feedback message that populates the percent completed.
+
+        Returns:
+            :class:`py_trees_actions.Dock_Feedback`: the populated feedback message
         """
-        # TODO: send some feedback message
         msg = py_trees_actions.Dock_Feedback(
             percentage_completed=self.percent_completed
         )
@@ -63,7 +79,7 @@ class Dock(py_trees_ros.mock.actions.GenericServer):
 
 def main():
     """
-    Entry point for the mock batttery node.
+    Entry point for the mocked docking controller.
     """
     parser = argparse.ArgumentParser(description='Mock a docking controller')
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]

--- a/py_trees_ros_tutorials/mock/gui/__init__.py
+++ b/py_trees_ros_tutorials/mock/gui/__init__.py
@@ -7,7 +7,7 @@
 ##############################################################################
 
 """
-Generated gui modules for the mock robot.
+Generated qt modules for the mock robot dashboard.
 """
 ##############################################################################
 # Imports

--- a/py_trees_ros_tutorials/mock/launch.py
+++ b/py_trees_ros_tutorials/mock/launch.py
@@ -24,8 +24,13 @@ import py_trees_ros_tutorials.utilities as utilities
 ##############################################################################
 
 
-def generate_launch_description():
-    """Launch the mock robot."""
+def generate_launch_description() -> launch.LaunchDescription:
+    """
+    Launch the mock robot (i.e. launch all mocked components).
+
+    Returns:
+        :class:`launch.LaunchDescription`
+    """
 
     launch_description = launch.LaunchDescription()
 
@@ -51,8 +56,8 @@ def generate_launch_description():
 ##############################################################################
 
 
-def main():
-    """A rosrunnable launch."""
+def main() -> int:
+    """Entry point for launching the mocked robot"""
     launch_descriptions = []
     launch_descriptions.append(generate_launch_description())
     launch_service = utilities.generate_ros_launch_service(

--- a/py_trees_ros_tutorials/mock/move_base.py
+++ b/py_trees_ros_tutorials/mock/move_base.py
@@ -24,8 +24,6 @@ import py_trees_ros_interfaces.action as py_trees_actions
 import rclpy
 import sys
 
-from . import actions
-
 ##############################################################################
 # Class
 ##############################################################################
@@ -33,10 +31,18 @@ from . import actions
 
 class MoveBase(py_trees_ros.mock.actions.GenericServer):
     """
-    Simulates a move base style interface
+    Simulates a move base style interface.
+
+    Node Name:
+        * **move_base_controller**
+
+    Action Servers:
+        * **/move_base** (:class:`py_trees_ros_interfaces.action.MoveBase`)
+
+          * point to point move base action
 
     Args:
-        duration (:obj:`int`): time for a goal to complete (seconds)
+        duration: mocked duration of a successful action
     """
     def __init__(self, duration=None):
         super().__init__(
@@ -49,9 +55,12 @@ class MoveBase(py_trees_ros.mock.actions.GenericServer):
         self.pose = geometry_msgs.PoseStamped()
         self.pose.pose.position = geometry_msgs.Point(x=0.0, y=0.0, z=0.0)
 
-    def generate_feedback_message(self):
+    def generate_feedback_message(self) -> py_trees_actions.MoveBase_Feedback:
         """
-        Increment the odometry and pose towards the goal.
+        Do a fake pose incremenet and populate the feedback message.
+
+        Returns:
+            :class:`py_trees_actions.MoveBase_Feedback`: the populated feedback message
         """
         # actually doesn't go to the goal right now...
         # but we could take the feedback from the action
@@ -65,7 +74,7 @@ class MoveBase(py_trees_ros.mock.actions.GenericServer):
 
 def main():
     """
-    Entry point for the mock batttery node.
+    Entry point for the mock move base node.
     """
     parser = argparse.ArgumentParser(description='Mock a docking controller')
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]

--- a/py_trees_ros_tutorials/mock/rotate.py
+++ b/py_trees_ros_tutorials/mock/rotate.py
@@ -24,8 +24,6 @@ import py_trees_ros_interfaces.action as py_trees_actions
 import rclpy
 import sys
 
-from . import actions
-
 ##############################################################################
 # Class
 ##############################################################################
@@ -35,10 +33,18 @@ class Rotate(py_trees_ros.mock.actions.GenericServer):
     """
     Simple server that controls a full rotation of the robot.
 
+    Node Name:
+        * **rotation_controller**
+
+    Action Servers:
+        * **/rotate** (:class:`py_trees_ros_interfaces.action.Dock`)
+
+          * motion primitives - rotation server
+
     Args:
-        rotation_rate (:obj:`float`): rate of rotation )rad/s)
+        rotation_rate (:obj:`float`): rate of rotation (rad/s)
     """
-    def __init__(self, rotation_rate=1.57):
+    def __init__(self, rotation_rate: float=1.57):
         super().__init__(node_name="rotation_controller",
                          action_name="rotate",
                          action_type=py_trees_actions.Rotate,
@@ -48,7 +54,10 @@ class Rotate(py_trees_ros.mock.actions.GenericServer):
 
     def generate_feedback_message(self):
         """
-        Create some appropriate feedback.
+        Create a feedback message that populates the percent completed.
+
+        Returns:
+            :class:`py_trees_actions.Rotate_Feedback`: the populated feedback message
         """
         # TODO: send some feedback message
         msg = py_trees_actions.Rotate_Feedback()  # Rotate.Feedback() works, but the indexer can't find it
@@ -59,9 +68,9 @@ class Rotate(py_trees_ros.mock.actions.GenericServer):
 
 def main():
     """
-    Entry point for the mock batttery node.
+    Entry point for the mock rotation controller node.
     """
-    parser = argparse.ArgumentParser(description='Mock a docking controller')
+    parser = argparse.ArgumentParser(description='Mock a rotation controller')
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]
     parser.parse_args(command_line_args)
     rclpy.init()  # picks up sys.argv automagically internally

--- a/py_trees_ros_tutorials/mock/safety_sensors.py
+++ b/py_trees_ros_tutorials/mock/safety_sensors.py
@@ -34,7 +34,10 @@ class SafetySensors(object):
     cpu resources can be efficiently optimised or to resolve contextual
     conflicts in the usage of the sensors.
 
-    Dynamic Reconfigure:
+    Node Name:
+        * **safety_sensors**
+
+    Dynamic Parameters:
         * **~enable** (:obj:`bool`)
 
           * enable/disable the safety sensor pipeline (default: False)
@@ -52,7 +55,7 @@ class SafetySensors(object):
 
     def spin(self):
         """
-        Spin around, updating battery state and publishing the result.
+        Spin, and finally shutdown ROS components.
         """
         try:
             rclpy.spin(self.node)
@@ -63,7 +66,7 @@ class SafetySensors(object):
 
 def main():
     """
-    Entry point for the mock batttery node.
+    Entry point for the mock safety sensors node.
     """
     parser = argparse.ArgumentParser(description='Mock the safety sensors')
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]

--- a/py_trees_ros_tutorials/utilities.py
+++ b/py_trees_ros_tutorials/utilities.py
@@ -33,8 +33,8 @@ def generate_ros_launch_service(
     standalone launchers can be executed via ros2 run.
 
     Args:
-        launch_descriptions (:obj:`list` of :class:`~launch.LaunchDescription`): launch descriptions to include
-        bool (:obj:`bool): enable debugging on the launch service
+        launch_descriptions: launch descriptions to include
+        bool: enable debugging on the launch service
 
     Returns:
         :class:`launch.LaunchService`: service to execute

--- a/py_trees_ros_tutorials/version.py
+++ b/py_trees_ros_tutorials/version.py
@@ -7,8 +7,7 @@
 ##############################################################################
 
 """
-Version number provided separately here so there is easy access for the module,
-setup.py and sphinx.
+Version number accessible to users of the package.
 """
 
 ##############################################################################


### PR DESCRIPTION
Incidentally also updates to use `autodoc_mock_imports` with sphinx > 1.7.5 so classes inheriting from mocks are not skipped.