### PR TITLE
2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,13 @@ Changelog
 
 Forthcoming
 -----------
+* [tutorials] fix: grammar mistake (`#51 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/51>`_)
+* [doc] some fresh dot files
+* [mock] update for new shutdown handling for humble
+* [docs] update intersphinx releases to latest py_trees releases
+* [tutorials] refactor for explicit composite arguments
 * [mock] bugfix signal type mismatch for charging status
-* [tutorials] explicit constructure arguments
-* [tutorials] bugfix shutdown on humble
+* Contributors: Daniel Stonier, Humaney
 
 2.1.0 (2020-08-02)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog
 =========
 
-Forthcoming
------------
+2.3.0 (2025-01-11)
+------------------
 * [tutorials] fix: grammar mistake (`#51 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/51>`_)
 * [doc] some fresh dot files
 * [mock] update for new shutdown handling for humble

--- a/package.xml
+++ b/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>py_trees_ros_tutorials</name>
-  <version>2.1.0</version>
+  <version>2.3.0</version>
   <description>
-    ROS2 extensions and behaviours for py_trees.
+    Tutorials for py_trees on ROS2.
   </description>
 
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -7,15 +7,15 @@
     Tutorials for py_trees on ROS2.
   </description>
 
+  <author>Daniel Stonier</author>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
+  <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
 
   <license>BSD</license>
 
   <url type="website">https://py-trees-ros-tutorials.readthedocs.io/en/release-2.0.x/</url>
   <url type="repository">https://github.com/splintered-treality/py_trees_ros_tutorials</url>
   <url type="bugtracker">https://github.com/splintered-treality/py_trees_ros_tutorials/issues</url>
-
-  <author>Daniel Stonier</author>
 
   <build_depend>python3-setuptools</build_depend>
   <build_depend>pyqt5-dev-tools</build_depend>

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     },
     name=package_name,
     # also update package.xml (version and website url), version.py and conf.py
-    version='2.1.0',
+    version='2.3.0',
     packages=find_packages(exclude=['tests*', 'docs*', 'launch*']),
     data_files=[
         ('share/' + package_name, ['package.xml']),

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     install_requires=[],  # it's all lies (c.f. package.xml, but no use case for this yet)
     extras_require={},
     author='Daniel Stonier',
-    maintainer='Daniel Stonier <d.stonier@gmail.com>',
+    maintainer='Daniel Stonier <d.stonier@gmail.com>, Sebastian Castro <sebas.a.castro@gmail.com>',
     url='https://github.com/splintered-reality/py_trees_ros_tutorials',
     keywords=['ROS', 'ROS2', 'behaviour-trees'],
     zip_safe=True,


### PR DESCRIPTION
For this one, I've decided to skip straight from 2.1.0 to 2.3.0 just to put it on the same version as `py_trees` / `py_trees_ros`.

It seemed appropriate, but let me know if otherwise.